### PR TITLE
Merge in Flagger

### DIFF
--- a/src/flagger.vale
+++ b/src/flagger.vale
@@ -1,0 +1,270 @@
+// NOTE(Alec):
+//     THIS IS BORKED!
+// 
+//     When building, you will get a big, scary error!
+//     Let's just wait for Verdagon to fix that...
+
+
+// A full representation of a possible flag.
+// 
+// # fields:
+// * name The name of the flag (e.g. --foo, --bar, etc.)
+// * type The type of the flag. I would say this is an enum, but
+//            those aren't in Vale yet... so here is the documentation
+//            for the different types:
+//            * NOTHING = 0 -> This means the flag is standalone and takes no value.
+//            * INT = 1 -> This means the flag takes an @int value.
+//            * STR = 2 -> This means the flag takes a @str value (parsed by the command line).
+//            * TOKN = 3 -> This means the flag takes a `token` value (@str). This is essentially the same
+//                          as the `STR` value, but is different in semantics alone.
+//            * BOOL = 4 -> This means the flag takes a @bool value (true/false).
+//            * LIST_INT = 4 -> This means the flag takes a @List<int>. The values are delineated
+//                              individually through whitespace (parsed by the command line).
+//            * LIST_STR -> This means the flag takes a @List<str>. Same structure as `LIST_INT`.
+//            * LIST_TOKN -> This means the flag takes a @List<str>. Same structure as `LIST_INT`.
+//            * LIST_BOOL -> This means the flag takes a @List<bool>. Same structure as `LIST_INT`.
+//            * LIST_ANY -> This means the flag takes a @List<FlagType>. Same structure as `LIST_INT`.
+// * desc The long description of the flag. This will eventually be used in `[command] --help [flag]`.
+// * short_desc The short description of the flag. This will eventually be used in `[command] --help`.
+// * example An example of how to use the flag. This will eventually be used in `[command] --help [flag]`.
+struct Flag {
+    name str;
+    type int; // INT, STR, TOKN, BOOL, or the LIST values.
+
+    desc str;
+    short_desc str;
+
+    example str;
+}
+
+// const NOTHING = 0;
+
+// const INT  = 1;
+// const STR  = 2;
+// const TOKN = 3;
+// const BOOL = 4;
+
+// const LIST_INT  = 5;
+// const LIST_STR  = 6;
+// const LIST_TOKN = 7;
+// const LIST_BOOL = 8;
+// const LIST_ANY  = 9;
+
+// The result of a flag that has been parsed.
+// 
+// # fields:
+// * name The name of the flag (should be identical to @Flag::name).
+// * val The value of the flag. Can be any variation of @FlagType.
+struct ParsedFlag {
+    name str;
+    val  FlagType;
+}
+
+// A list of @ParsedFlag and invalid flags, which are stored as a @List<str>
+// 
+// # fields:
+// * parsed_flags The successfully parsed flags.
+// * invalid_flags Unsuccessfully parsed flags. Flagger stores these so that
+//                     the user can later go in and either validate the flags
+//                     through some other means or give more descriptive
+//                     error messages for the flags.
+struct ParsedFlagList {
+    parsed_flags  List<ParsedFlag>;
+    invalid_flags List<str>;
+}
+
+// A statically-sized list of @Command. Commands are different from
+// flags in that they take no values. An example of a command vs a
+// flag would be `vale build` vs `--verbose`.
+// 
+// ... Maybe one day we can get a self-hosted CLI like that... A Valer can but dream.
+struct CommandList<N> { commands [N * Command]; }
+
+// As described in @CommandList, a `Command` takes no arguments. It is simply
+// a subcommand within the main command, such as `vale build`, where `build` is
+// the command.
+// 
+// # fields:
+// * name The name of the command (e.g. build, run, etc.).
+// * desc The long description of the command. This will eventually be used in `[command] --help [subcommand]`.
+// * short_desc The short description of the command. This will eventually be used in `[command] --help`.
+// * example An example of the command. This will eventually be used in `[command] --help [subcommand]`.
+struct Command {
+    name str;
+    desc str;
+
+    short_desc str;
+
+    example str;
+}
+
+// A wack union of flag types. The valid flag value types are:
+// 1) @FlagInt
+// 2) @FlagString
+// 3) @FlagToken
+// 4) @FlagBool
+// 5) @FlagAnyList
+// 
+// This will later have other `LIST` types.
+// 
+// All flag value types have only one field, `value`.
+interface FlagType { }
+
+// An @int variant of @FlagType.
+struct FlagInt { value int; }
+impl FlagType for FlagInt;
+
+// A @str variant of @FlagType.
+struct FlagString { value str; }
+impl FlagType for FlagString;
+
+// A `token` (@str) variant of @FlagType.
+struct FlagToken { value str; }
+impl FlagType for FlagToken;
+
+// A @bool variant of @FlagType.
+struct FlagBool { value bool; }
+impl FlagType for FlagBool;
+
+// A @List<FlagType> variant of @FlagType.
+struct FlagAnyList { value List<FlagType>; }
+impl FlagType for FlagAnyList;
+
+// Verifies a @Command matches one of the commands in the @CommandList.
+// 
+// # generics:
+// * N The size of the @CommandList passed implicitly through parametric polymorphism.
+// 
+// # params:
+// * command_list The command list created by the user.
+// * command_str The possible command to be verified.
+//
+// # returns:
+// 1) Whether the string is a valid @Command
+fn verify<N>(command_list &CommandList<N>, command_str str) bool {
+    valid! = false;
+
+    command_list.flags.each((cmd){
+        if (valid) {
+            ret void();
+        }
+
+        mut valid = cmd.name == command_str;
+    });
+
+    = valid;
+}
+
+// Parses all flags within the arguments.
+// Any invalid flags can be handled however the user wishes.
+// 
+// # generics:
+// * N The size of the @[Command].
+// 
+// # params:
+// * flag_list An array created by the user.
+// * args The command line arguments (skips the `[command]`).
+// 
+// # returns:
+// 1) A list of parsed and invalid flags.
+fn parse_all_flags<N>(flag_list [N * Flag], args Array<imm, str>) ParsedFlagList {
+    parsed_flag_list = ParsedFlagList(List<ParsedFlag>(), List<str>());
+
+    i! = 1;
+
+    while (i < len(args)) {
+        arg = args[i];
+
+        valid!     = false;
+        flag_type! = 0; // TODO: NOTHING
+
+        flag_list.each((flag){
+            if (valid) {
+                mut flag_type = flag.type;
+                ret void();
+            }
+
+            mut valid = flag.name == arg;
+        });
+
+        if (valid and flag_type != 0) { // TODO: NOTHING
+            parsed_flag_list.parsed_flags.add(parse_flag(args, flag_type, &i));
+        }
+
+        else if (flag_type == 0) {
+            parsed_flag_list.parsed_flags.add(ParsedFlag(args[i], FlagString("")));
+        }
+
+        else {
+            parsed_flag_list.invalid_flags.add(arg);
+        }
+
+        mut i = i + 1;
+    }
+
+    = parsed_flag_list;
+}
+
+// Parses a single flag and its value given its information.
+// Any invalid flags can be handled however the user wishes.
+// 
+// # params:
+// * args The command line arguments (skips the `[command]`).
+// * flag_type The type of the flag (see @Flag for more).
+// * i The iteration count for the arguments. Will mutate.
+// 
+// # returns:
+// 1) A list of parsed and invalid flags.
+fn parse_flag(args Array<imm, str>, flag_type int, i &int) ParsedFlag {
+    name = args[i];
+
+    // Curse Verdagon and his lack of matches! lol
+
+    if (flag_type == 0) { // NOTHING
+        vassert(false, "Invalid flag type was passed");
+
+        = ParsedFlag(name, FlagString(""));
+    }
+
+    else if (flag_type == 1) { // INT
+        mut i = i + 1;
+        
+        val = int(args[i].slice());
+
+        vassert(not val.isEmpty(), "Argument " + str(i) + " \"" + args[i] + "\" is not an int.");
+
+        = ParsedFlag(name, FlagInt(val.get()));
+    }
+
+    else if (flag_type == 2) { // STR
+        mut i = i + 1;
+        = ParsedFlag(name, FlagString(args[i]));
+    }
+
+    else if (flag_type == 3) { // TOKN
+        mut i = i + 1;
+        = ParsedFlag(name, FlagToken(args[i]));
+    }
+
+    else if (flag_type == 4) { // BOOL
+        mut i = i + 1;
+
+        val = args[i] == "true";
+
+        vassert((not val and args[i] == "false") or val, "Invalid bool value \"" + args[i] + "\" for flag \"" + args[i - 1] + "\".");
+
+        = ParsedFlag(name, FlagBool(val));
+    }
+
+    else {
+        vassert(false, "Invalid flag type was passed");
+
+        = ParsedFlag(name, FlagString(""));
+    }
+
+    vassert(false, "Invalid or unimplemented type has been passed.");
+
+    = ParsedFlag("", FlagString(""));
+
+    // TODO: List types
+}


### PR DESCRIPTION
Merges (currently broken, awaiting changes in the compiler) Flagger into the standard library.

Notes for future improvements:
1) Command could potentially just be outright removed.
2) Implementing list types.
3) Adding match/switch whenever it is implemented to `parse_all_flags`.
4) Will need to conform with whatever standards are finally chosen for Vale documentation.